### PR TITLE
Register permissions callback only when needed

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,5 +3,5 @@
   <uses-sdk android:minSdkVersion="18" />
   <uses-permission android:name="android.permission.BLUETOOTH" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 </manifest>

--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -59,7 +59,7 @@ import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
 public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsResultListener  {
     private static final String TAG = "FlutterBluePlugin";
     private static final String NAMESPACE = "plugins.pauldemarco.com/flutter_blue";
-    private static final int REQUEST_COARSE_LOCATION_PERMISSIONS = 1452;
+    private static final int REQUEST_FINE_LOCATION_PERMISSIONS = 1452;
     static final private UUID CCCD_ID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
     private final Registrar registrar;
     private final Activity activity;
@@ -151,14 +151,14 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
 
             case "startScan":
             {
-                if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_COARSE_LOCATION)
+                if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
                         != PackageManager.PERMISSION_GRANTED) {
                     ActivityCompat.requestPermissions(
                             activity,
                             new String[] {
-                                    Manifest.permission.ACCESS_COARSE_LOCATION
+                                    Manifest.permission.ACCESS_FINE_LOCATION
                             },
-                            REQUEST_COARSE_LOCATION_PERMISSIONS);
+                            REQUEST_FINE_LOCATION_PERMISSIONS);
                     pendingCall = call;
                     pendingResult = result;
                     break;
@@ -551,7 +551,7 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
     @Override
     public boolean onRequestPermissionsResult(
             int requestCode, String[] permissions, int[] grantResults) {
-        if (requestCode == REQUEST_COARSE_LOCATION_PERMISSIONS) {
+        if (requestCode == REQUEST_FINE_LOCATION_PERMISSIONS) {
             if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 startScan(pendingCall, pendingResult);
             } else {

--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -79,7 +79,6 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
      */
     public static void registerWith(Registrar registrar) {
         final FlutterBluePlugin instance = new FlutterBluePlugin(registrar);
-        registrar.addRequestPermissionsResultListener(instance);
     }
 
     FlutterBluePlugin(Registrar r){
@@ -153,6 +152,7 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
             {
                 if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
                         != PackageManager.PERMISSION_GRANTED) {
+                    registrar.addRequestPermissionsResultListener(this);
                     ActivityCompat.requestPermissions(
                             activity,
                             new String[] {

--- a/ios/flutter_blue.podspec
+++ b/ios/flutter_blue.podspec
@@ -31,7 +31,6 @@ A new flutter plugin project.
 
   s.subspec 'Protos' do |ss|
     ss.source_files = 'gen/**/*.pbobjc.{h,m}'
-    ss.header_mappings_dir = 'gen'
     ss.requires_arc = false
     ss.dependency 'Protobuf'
   end

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -22,7 +22,7 @@ class BluetoothCharacteristic {
   }
 
   BehaviorSubject<List<int>> _value;
-  Stream<List<int>> get value => Observable.merge([
+  Stream<List<int>> get value => Rx.merge([
         _value.stream,
         _onValueChangedStream,
       ]);

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -87,7 +87,7 @@ class FlutterBlue {
     final killStreams = <Stream>[];
     killStreams.add(_stopScanPill);
     if (timeout != null) {
-      killStreams.add(Observable.timer(null, timeout));
+      killStreams.add(Rx.timer(null, timeout));
     }
 
     // Clear scan results list
@@ -102,10 +102,8 @@ class FlutterBlue {
       throw e;
     }
 
-    yield* Observable(FlutterBlue.instance._methodStream
-            .where((m) => m.method == "ScanResult")
-            .map((m) => m.arguments))
-        .takeUntil(Observable.merge(killStreams))
+    yield* FlutterBlue.instance._methodStream.where((m) => m.method == "ScanResult").map((m) => m.arguments)
+        .takeUntil(Rx.merge(killStreams))
         .doOnDone(stopScan)
         .map((buffer) => new protos.ScanResult.fromBuffer(buffer))
         .map((p) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   convert: "^2.1.1"
   protobuf: "^0.14.1"
-  rxdart: "^0.22.0"
+  rxdart: "^0.23.1"
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes a crash, but prevents app from learning that the user has blocked permissions after app has started running (when permissions had been granted at app start I *think* that is the best we can do, though?

Also requires https://github.com/resideo/flutter_sweet_blue/pull/1 